### PR TITLE
[Fix] 가맹점 관리자 페이지의 목차 수정

### DIFF
--- a/frontend/store/src/components/SideComponent.vue
+++ b/frontend/store/src/components/SideComponent.vue
@@ -38,6 +38,14 @@
               </router-link>
             </li>
             <li class="sidebar-item">
+              <router-link class="sidebar-link" to="/orderdetail">
+                <span>
+                  <i class="ti ti-wallet"></i>
+                </span>
+                <span class="hide-menu">주문내역</span>
+              </router-link>
+            </li>
+            <li class="sidebar-item">
               <router-link class="sidebar-link" to="/stockedit">
                 <span>
                   <i class="ti ti-alert-circle"></i>
@@ -67,17 +75,7 @@
                   <i class="ti ti-typography"></i>
                 </span>
                 <span class="hide-menu">문의사항</span>
-              </router-link>
-              
-            </li>
-            <li class="sidebar-item">
-              <router-link class="sidebar-link" to="/orderdetail">
-                <span>
-                  <i class="ti ti-typography"></i>
-                </span>
-                <span class="hide-menu">주문내역</span>
-              </router-link>
-              
+              </router-link>              
             </li>
           </ul>
         </nav>


### PR DESCRIPTION
가맹점 관리자 페이지의 목차에 주문내역 항목이 빠져있어서 추가하고 수정했습니다.

#72